### PR TITLE
Handle PDF MIME type

### DIFF
--- a/.github/workflows/03_update.yml
+++ b/.github/workflows/03_update.yml
@@ -1,0 +1,48 @@
+name: 03 - Update Elo Ratings
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["02 - PDF Content Extraction"]
+    types:
+      - completed
+
+jobs:
+  update:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "/root/.cargo/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Install dependencies
+        run: uv pip install -r requirements.txt
+
+      - name: Run pipeline
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY_PLACEHOLDER }}
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+          python causaganha/legalelo/pipeline.py run --date $DATE
+
+      - name: Commit updated ratings
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add causaganha/data/ratings.csv causaganha/data/partidas.csv
+          if git diff --cached --quiet; then
+            echo "No CSV changes to commit"
+          else
+            git commit -m "Update Elo ratings" && git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CausaGanha
 
+[![Update Elo Ratings](https://github.com/OWNER/REPO/actions/workflows/03_update.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/03_update.yml)
+
 **CausaGanha** é uma plataforma automatizada de extração e análise de decisões judiciais que aplica o sistema de pontuação **Elo** — originalmente desenvolvido para classificar jogadores de xadrez — à atuação de advogados em processos judiciais. A proposta consiste em construir um modelo dinâmico e transparente de avaliação de desempenho com base em decisões publicadas diariamente no Diário de Justiça do Tribunal de Justiça de Rondônia (TJRO).
 
 Utilizando modelos de linguagem de grande escala (LLMs), especificamente o **Gemini** da Google, o sistema interpreta diretamente os arquivos em formato PDF, identifica os elementos relevantes de cada decisão (partes, representantes e resultado), e atualiza o histórico e o escore de cada advogado envolvido.

--- a/causaganha/legalelo/extractor.py
+++ b/causaganha/legalelo/extractor.py
@@ -76,8 +76,10 @@ class GeminiExtractor:
             uploaded_file_object = None
             try:
                 logging.info(f"Uploading {pdf_path.name} to Gemini...")
-                # TODO: Consider adding MIME type if API benefits from it, e.g., 'application/pdf'
-                uploaded_file_object = genai.upload_file(path=str(pdf_path))
+                uploaded_file_object = genai.upload_file(
+                    path=str(pdf_path),
+                    mime_type="application/pdf",
+                )
                 logging.info(f"Successfully uploaded {pdf_path.name} as {uploaded_file_object.name}")
 
                 prompt = """Analise este PDF do Diário da Justiça e extraia APENAS decisões judiciais.

--- a/causaganha/tests/test_extractor.py
+++ b/causaganha/tests/test_extractor.py
@@ -69,7 +69,9 @@ class TestGeminiExtractor(unittest.TestCase):
         self.assertTrue(pathlib.Path(result_path).exists())
 
         mock_genai.configure.assert_called_once_with(api_key="fake_key_for_test")
-        mock_genai.upload_file.assert_called_once_with(path=str(self.dummy_pdf_path))
+        mock_genai.upload_file.assert_called_once_with(
+            path=str(self.dummy_pdf_path), mime_type="application/pdf"
+        )
         mock_genai.GenerativeModel.assert_called_once_with('gemini-1.5-flash')
         # Check that generate_content was called (args are complex, check it was called)
         self.assertTrue(mock_model_instance.generate_content.called)


### PR DESCRIPTION
## Summary
- add update workflow for Elo ratings
- show workflow badge in README
- include PDF MIME type when uploading to Gemini

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fa43948bc83259119d005fba7f546