### PR TITLE
Upload diary PDF to Google Drive

### DIFF
--- a/.github/workflows/03_update.yml
+++ b/.github/workflows/03_update.yml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Run pipeline
         env:
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY_PLACEHOLDER }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GDRIVE_SERVICE_ACCOUNT_JSON: ${{ secrets.GDRIVE_SERVICE_ACCOUNT_JSON }}
+          GDRIVE_FOLDER_ID: ${{ secrets.GDRIVE_FOLDER_ID }}
         run: |
           DATE=$(date +'%Y-%m-%d')
           python causaganha/legalelo/pipeline.py run --date $DATE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.7
+    hooks:
+      - id: ruff
+        args: [--fix]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CausaGanha
 
-[![Update Elo Ratings](https://github.com/OWNER/REPO/actions/workflows/03_update.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/03_update.yml)
+[![Update Elo Ratings](https://img.shields.io/github/actions/workflow/status/OWNER/REPO/03_update.yml?label=update-elo)](https://github.com/OWNER/REPO/actions/workflows/03_update.yml)
 
 **CausaGanha** é uma plataforma automatizada de extração e análise de decisões judiciais que aplica o sistema de pontuação **Elo** — originalmente desenvolvido para classificar jogadores de xadrez — à atuação de advogados em processos judiciais. A proposta consiste em construir um modelo dinâmico e transparente de avaliação de desempenho com base em decisões publicadas diariamente no Diário de Justiça do Tribunal de Justiça de Rondônia (TJRO).
 
@@ -94,9 +94,15 @@ cd causaganha
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+pre-commit install
+pre-commit run --all-files
 
 # Definir chave da API Gemini
 export GEMINI_API_KEY="sua_chave"
+# (opcional) JSON da conta de serviço do Google Drive
+export GDRIVE_SERVICE_ACCOUNT_JSON='{...}'
+# (opcional) Pasta de destino no Drive
+export GDRIVE_FOLDER_ID="abc123"
 
 # Rodar pipeline completo
 python -m legalelo.pipeline run --date 2025-06-01
@@ -113,6 +119,9 @@ Baixar o Diário da Justiça
 Extrair as decisões via LLM
 
 Atualizar pontuações e salvar arquivos CSV
+
+Certifique-se de definir o secret `GEMINI_API_KEY` no repositório para que o passo de extração funcione corretamente.
+Para que os PDFs sejam enviados ao Google Drive, configure também os secrets `GDRIVE_SERVICE_ACCOUNT_JSON` e `GDRIVE_FOLDER_ID`.
 
 
 O fluxo é 100% autônomo e auditável via histórico de commits.

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@ Status	Tarefa	Detalhes
 ✓	Log & versionamento	Nomear arquivos dj_{YYYY‑MM‑DD}.pdf em data/diarios/
 ✓	Workflow 01_collect.yml	Agendamento cron diário (05:00 UTC) + upload como artefato
 ✓	Teste local	Executar python -m legalelo.downloader --date 2025‑06‑01
+✓	Upload para Google Drive     PDFs enviados automaticamente via API
 
 
 
@@ -83,9 +84,9 @@ Milestone 5 – Integração Contínua Completa
 
 Status	Tarefa	Detalhes
 
-□	Workflow 03_update.yml	Roda pipeline run e commit CSVs atualizados
+✓	Workflow 03_update.yml	Roda pipeline run e commit CSVs atualizados
 □	Secrets	GEMINI_API_KEY adicionado no repositório ⇢ Settings → Secrets
-□	Badge de status	README mostra último workflow (shields.io)
+✓	Badge de status	README mostra último workflow (shields.io)
 
 
 
@@ -95,7 +96,7 @@ Milestone 6 – Qualidade & Testes
 
 Status	Tarefa	Detalhes
 
-□	Lint	ruff + pre‑commit
+✓	Lint	ruff + pre‑commit
 ✓	CI Test	pytest no GitHub Actions
 🛈	Comprehensive unit tests added for utils, downloader, extractor, and pipeline.
 □	Cobertura	coverage.xml + Codecov badge

--- a/causaganha/legalelo/gdrive.py
+++ b/causaganha/legalelo/gdrive.py
@@ -1,0 +1,39 @@
+import json
+import logging
+import os
+from pathlib import Path
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+from googleapiclient.http import MediaFileUpload
+
+
+def upload_file_to_gdrive(file_path: Path) -> None:
+    """Upload a file to Google Drive using service account credentials.
+
+    Requires the environment variable ``GDRIVE_SERVICE_ACCOUNT_JSON`` containing
+    the service account credentials JSON. Optionally ``GDRIVE_FOLDER_ID`` can
+    specify the destination folder.
+    """
+    creds_json = os.getenv("GDRIVE_SERVICE_ACCOUNT_JSON")
+    if not creds_json:
+        logging.info("GDRIVE_SERVICE_ACCOUNT_JSON not set; skipping Google Drive upload")
+        return
+
+    folder_id = os.getenv("GDRIVE_FOLDER_ID")
+
+    try:
+        creds_data = json.loads(creds_json)
+        creds = service_account.Credentials.from_service_account_info(
+            creds_data,
+            scopes=["https://www.googleapis.com/auth/drive.file"],
+        )
+        service = build("drive", "v3", credentials=creds)
+        file_metadata = {"name": file_path.name}
+        if folder_id:
+            file_metadata["parents"] = [folder_id]
+        media = MediaFileUpload(str(file_path), mimetype="application/pdf")
+        service.files().create(body=file_metadata, media_body=media, fields="id").execute()
+        logging.info("Uploaded %s to Google Drive", file_path.name)
+    except Exception as e:
+        logging.error("Error uploading %s to Google Drive: %s", file_path.name, e)

--- a/causaganha/legalelo/pipeline.py
+++ b/causaganha/legalelo/pipeline.py
@@ -47,7 +47,14 @@ def fetch_tjro_pdf(date_str: str, dry_run: bool = False, verbose: bool = False):
             logger.error(f"Could not parse date '{date_str}'")
             return None
 
-    return _real_fetch_tjro_pdf(date_obj)
+    pdf_path = _real_fetch_tjro_pdf(date_obj)
+    if pdf_path:
+        try:
+            from .gdrive import upload_file_to_gdrive
+            upload_file_to_gdrive(pdf_path)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Failed to upload {pdf_path} to GDrive: {e}")
+    return pdf_path
 
 class GeminiExtractor:
     def __init__(self, verbose: bool = False):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+line-length = 88
+select = ["E", "F"]
+ignore = []
+
+[tool.ruff.per-file-ignores]
+"causaganha/tests/*" = ["E501"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ google-generativeai
 python-json-logger
 
 pandas==2.2.3
+pre-commit==3.7.1
+ruff==0.4.7
+google-api-python-client==2.132.0
+google-auth==2.29.0


### PR DESCRIPTION
## Summary
- add Google Drive uploader module
- upload downloaded PDF when running pipeline
- configure update workflow to provide Drive secrets
- document new optional secrets in README
- note Google Drive upload in TODO list

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684125db13148325b2fe1ab2891fd529