### PR TITLE
Centralize logging setup

### DIFF
--- a/causaganha/legalelo/downloader.py
+++ b/causaganha/legalelo/downloader.py
@@ -5,9 +5,6 @@ import requests
 import argparse  # Added
 import logging  # Added
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 # URL where the official diary page lists the PDF link
 TJRO_DIARIO_OFICIAL_URL = "https://www.tjro.jus.br/diario_oficial/"
 TJRO_LATEST_PAGE_URL = "https://www.tjro.jus.br/diario_oficial/ultimo-diario.php"

--- a/causaganha/legalelo/elo.py
+++ b/causaganha/legalelo/elo.py
@@ -14,8 +14,6 @@ import logging
 # processing before Elo updates.
 # --- End Advogado ID Management Note ---
 
-# Configure basic logging for module-level feedback if run directly
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
 
 DEFAULT_K_FACTOR = 16
 
@@ -71,9 +69,6 @@ def update_elo(rating_a: float, rating_b: float, score_a: float, k_factor: int =
     return round(new_rating_a, 2), round(new_rating_b, 2) # Round to typical Elo precision
 
 if __name__ == '__main__':
-    # Configure basic logging for module-level feedback if run directly
-    # This is already at the top of the file, so it will apply.
-    # logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
 
     logging.info("="*50)
     logging.info("ELO CALCULATION DEMONSTRATION")

--- a/causaganha/legalelo/extractor.py
+++ b/causaganha/legalelo/extractor.py
@@ -6,9 +6,6 @@ import re
 import argparse
 import logging
 
-# Configure basic logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
 try:
     import google.generativeai as genai
 except ImportError:

--- a/causaganha/legalelo/utils.py
+++ b/causaganha/legalelo/utils.py
@@ -4,7 +4,6 @@ import logging # Added for validate_decision
 
 # It's good practice for a library module to not configure logging directly.
 # Instead, it should get a logger and use it. Application configures logging.
-# However, for __main__ block demonstrations, basicConfig is acceptable.
 logger = logging.getLogger(__name__)
 
 def normalize_lawyer_name(name: str) -> str:
@@ -153,9 +152,6 @@ def validate_decision(decision: dict) -> bool:
 
 
 if __name__ == '__main__':
-    # Configure logging for demonstration purposes within this block
-    logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(name)s: %(message)s')
-
     print("--- Testing normalize_lawyer_name function ---")
     examples_normalize = [
         "Dr. João Álves da Silva",


### PR DESCRIPTION
## Summary
- clean up logging setup in downloader, extractor, elo and utils
- keep configuration in `pipeline.setup_logging`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ed27c4c0832593cacbe9c199658a