### PR TITLE
Update workflow to fetch latest TJRO PDF

### DIFF
--- a/.github/workflows/01_collect.yml
+++ b/.github/workflows/01_collect.yml
@@ -31,9 +31,9 @@ jobs:
         id: date
         run: echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Run downloader script
+      - name: Run downloader script (latest)
         run: |
-          python causaganha/core/downloader.py --date ${{ steps.date.outputs.TODAY }}
+          python causaganha/core/downloader.py --latest
 
       - name: Upload downloaded PDF
         uses: actions/upload-artifact@v4

--- a/causaganha/core/downloader.py
+++ b/causaganha/core/downloader.py
@@ -74,29 +74,46 @@ def fetch_latest_tjro_pdf() -> pathlib.Path | None:
         return None
 
 def main(): # Added main function for CLI
-    parser = argparse.ArgumentParser(description="Download Diário da Justiça PDF from TJRO for a specific date.")
-    parser.add_argument(
+    parser = argparse.ArgumentParser(
+        description="Download Diário da Justiça PDF from TJRO."
+    )
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
         "--date",
         type=str,
-        required=True,
-        help="The date for which to download the Diário, in YYYY-MM-DD format."
+        help="The date for which to download the Diário, in YYYY-MM-DD format.",
+    )
+    group.add_argument(
+        "--latest",
+        action="store_true",
+        help="Download the most recent Diário available.",
     )
 
     args = parser.parse_args()
 
-    try:
-        selected_date = datetime.datetime.strptime(args.date, "%Y-%m-%d").date()
-    except ValueError:
-        logging.error("Invalid date format. Please use YYYY-MM-DD.")
-        return
+    if args.latest:
+        logging.info("Running downloader for latest diary")
+        file_path = fetch_latest_tjro_pdf()
+    else:
+        try:
+            selected_date = datetime.datetime.strptime(args.date, "%Y-%m-%d").date()
+        except ValueError:
+            logging.error("Invalid date format. Please use YYYY-MM-DD.")
+            return
 
-    logging.info(f"Running downloader for date: {selected_date.strftime('%Y-%m-%d')}")
-    file_path = fetch_tjro_pdf(selected_date)
+        logging.info(f"Running downloader for date: {selected_date.strftime('%Y-%m-%d')}")
+        file_path = fetch_tjro_pdf(selected_date)
 
     if file_path:
         logging.info(f"PDF downloaded to: {file_path}")
     else:
-        logging.warning(f"Failed to download PDF for {selected_date.strftime('%Y-%m-%d')}")
+        if args.latest:
+            logging.warning("Failed to download latest Diário")
+        else:
+            logging.warning(
+                f"Failed to download PDF for {selected_date.strftime('%Y-%m-%d')}"
+            )
 
 if __name__ == '__main__':
     main()

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,3 +8,8 @@ Defina o segredo `GEMINI_API_KEY` nas configurações do repositório.
 
 - Dependência de cota da API do Gemini.
 - Apenas o TJRO está implementado.
+
+**Como baixar manualmente o Diário?**
+
+Use o endereço https://www.tjro.jus.br/diario_oficial/ultimo-diario.php. Ele redireciona automaticamente para o PDF do dia. Caso veja a mensagem "Página Bloqueada", o site detectou acesso automático; tente abrir no navegador.
+


### PR DESCRIPTION
## Summary
- add `--latest` option in downloader CLI to retrieve most recent Diário
- use new flag in daily collection workflow
- document link to TJRO's latest Diário in FAQ

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b53dbe4f88325a657d29c31b1207f