### PR TITLE
Implement default TrueSkill config fallback

### DIFF
--- a/causaganha/core/trueskill_rating.py
+++ b/causaganha/core/trueskill_rating.py
@@ -3,6 +3,19 @@
 import trueskill
 import toml
 from pathlib import Path
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Valores padrao para o ambiente TrueSkill
+_DEFAULT_CONFIG = {
+    "mu": 25.0,
+    "sigma": 25.0 / 3,
+    "beta": (25.0 / 3) / 2,
+    "tau": (25.0 / 3) / 100,
+    "draw_probability": 0.10,
+    "backend": None,
+}
 
 # Carrega configurações do arquivo config.toml
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config.toml"
@@ -11,28 +24,15 @@ def load_trueskill_config():
     """Carrega as configurações do TrueSkill do arquivo config.toml."""
     try:
         config = toml.load(CONFIG_PATH)
-        return config.get("trueskill", {})
-    except FileNotFoundError:
+        return config.get("trueskill", _DEFAULT_CONFIG)
+    except FileNotFoundError as exc:
         # Fallback para valores padrão se config.toml não for encontrado
-        return {
-            "mu": 25.0,
-            "sigma": 25.0 / 3,
-            "beta": (25.0 / 3) / 2,
-            "tau": (25.0 / 3) / 100,
-            "draw_probability": 0.10,
-            "backend": None,
-        }
-    except Exception: # pylint: disable=broad-except
-        # Em caso de erro ao ler o toml, usa os padrões.
-        # Idealmente, logar o erro aqui.
-        return {
-            "mu": 25.0,
-            "sigma": 25.0 / 3,
-            "beta": (25.0 / 3) / 2,
-            "tau": (25.0 / 3) / 100,
-            "draw_probability": 0.10,
-            "backend": None,
-        }
+        logger.error("config.toml not found at %s: %s", CONFIG_PATH, exc)
+        return _DEFAULT_CONFIG
+    except Exception as exc:  # pylint: disable=broad-except
+        # Em caso de erro ao ler o toml, usa os padrões e loga o erro
+        logger.error("Failed to load TrueSkill config: %s", exc)
+        return _DEFAULT_CONFIG
 
 TS_CONFIG = load_trueskill_config()
 

--- a/causaganha/tests/test_trueskill_rating.py
+++ b/causaganha/tests/test_trueskill_rating.py
@@ -1,5 +1,8 @@
 import unittest
 import math
+from unittest.mock import patch
+import logging
+import toml
 
 import sys
 import pathlib
@@ -186,6 +189,24 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         p1_p2_after_match3_list, _ = ts_rating.update_ratings(self.env, team_p1_p2, team_p3_p4, "draw")
         r_player1 = p1_p2_after_match3_list[0]
         self.assertLess(r_player1.sigma, sigma_after_2_matches)
+
+
+class TestTrueSkillConfigLoading(unittest.TestCase):
+    def test_missing_config_uses_default_and_logs(self):
+        with patch.object(ts_rating.toml, "load", side_effect=FileNotFoundError("missing")):
+            with patch.object(logging.getLogger("causaganha.core.trueskill_rating"), "error") as mock_log:
+                config = ts_rating.load_trueskill_config()
+                self.assertEqual(config, ts_rating._DEFAULT_CONFIG)
+                mock_log.assert_called()
+                self.assertIn("missing", str(mock_log.call_args.args[2]))
+
+    def test_invalid_config_uses_default_and_logs(self):
+        err = toml.TomlDecodeError("boom", "", 0)
+        with patch.object(ts_rating.toml, "load", side_effect=err):
+            with patch.object(logging.getLogger("causaganha.core.trueskill_rating"), "error") as mock_log:
+                config = ts_rating.load_trueskill_config()
+                self.assertEqual(config, ts_rating._DEFAULT_CONFIG)
+                mock_log.assert_called_with("Failed to load TrueSkill config: %s", err)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `_DEFAULT_CONFIG` constant in `trueskill_rating.py`
- log and return `_DEFAULT_CONFIG` when config load fails
- test missing and invalid config handling and logging

## Testing
- `pytest causaganha/tests/test_trueskill_rating.py::TestTrueSkillConfigLoading::test_missing_config_uses_default_and_logs -q`
- `pytest causaganha/tests/test_trueskill_rating.py::TestTrueSkillConfigLoading::test_invalid_config_uses_default_and_logs -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c22e95a9883258b32d5280108e34e