### PR TITLE
Introduce MatchResult enum for TrueSkill updates

### DIFF
--- a/causaganha/core/trueskill_rating.py
+++ b/causaganha/core/trueskill_rating.py
@@ -4,6 +4,19 @@ import trueskill
 import toml
 from pathlib import Path
 from enum import Enum
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Valores padrao para o ambiente TrueSkill
+_DEFAULT_CONFIG = {
+    "mu": 25.0,
+    "sigma": 25.0 / 3,
+    "beta": (25.0 / 3) / 2,
+    "tau": (25.0 / 3) / 100,
+    "draw_probability": 0.10,
+    "backend": None,
+}
 
 
 class MatchResult(Enum):
@@ -20,28 +33,13 @@ def load_trueskill_config():
     """Carrega as configurações do TrueSkill do arquivo config.toml."""
     try:
         config = toml.load(CONFIG_PATH)
-        return config.get("trueskill", {})
-    except FileNotFoundError:
-        # Fallback para valores padrão se config.toml não for encontrado
-        return {
-            "mu": 25.0,
-            "sigma": 25.0 / 3,
-            "beta": (25.0 / 3) / 2,
-            "tau": (25.0 / 3) / 100,
-            "draw_probability": 0.10,
-            "backend": None,
-        }
-    except Exception: # pylint: disable=broad-except
-        # Em caso de erro ao ler o toml, usa os padrões.
-        # Idealmente, logar o erro aqui.
-        return {
-            "mu": 25.0,
-            "sigma": 25.0 / 3,
-            "beta": (25.0 / 3) / 2,
-            "tau": (25.0 / 3) / 100,
-            "draw_probability": 0.10,
-            "backend": None,
-        }
+        return config.get("trueskill", _DEFAULT_CONFIG)
+    except FileNotFoundError as exc:
+        logger.error("config.toml not found at %s: %s", CONFIG_PATH, exc)
+        return _DEFAULT_CONFIG
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error("Failed to load TrueSkill config: %s", exc)
+        return _DEFAULT_CONFIG
 
 TS_CONFIG = load_trueskill_config()
 

--- a/causaganha/tests/test_trueskill_rating.py
+++ b/causaganha/tests/test_trueskill_rating.py
@@ -10,7 +10,7 @@ sys.path.insert(
 
 # Importar o módulo e as constantes/funções a serem testadas
 from causaganha.core import trueskill_rating as ts_rating
-from causaganha.core.trueskill_rating import trueskill # Para criar Rating objects diretamente para comparação
+from causaganha.core.trueskill_rating import trueskill, MatchResult
 
 class TestTrueSkillRatingCalculations(unittest.TestCase):
 
@@ -43,7 +43,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha]
         team_b_before = [self.r_beta] # r_beta tem o mesmo rating que r_alpha
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, MatchResult.WIN_A)
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -70,7 +70,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [r_alpha_custom]
         team_b_before = [r_beta_custom]
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "draw")
+        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, MatchResult.DRAW)
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -86,7 +86,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha, self.r_beta] # Ambos com rating padrão
         team_b_before = [self.r_gamma]             # Rating padrão
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, MatchResult.WIN_A)
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_a[1]
@@ -110,7 +110,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_delta_expert] # Experiente
         team_b_before = [self.r_alpha]        # Novato (rating padrão)
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_b")
+        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, MatchResult.WIN_B)
 
         r_delta_after = new_team_a[0]
         r_alpha_after = new_team_b[0]
@@ -132,7 +132,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         r_std2_before = self.env.create_rating() # Jogador B padrão
 
         # Jogo padrão: Jogador B (std2) vence Jogador A (std1)
-        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(self.env, [r_std1_before], [r_std2_before], "win_b")
+        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(self.env, [r_std1_before], [r_std2_before], MatchResult.WIN_B)
         r_std1_after = r_std1_after_list[0]
         r_std2_after = r_std2_after_list[0]
 
@@ -157,13 +157,13 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         initial_sigma = r_player1.sigma
 
         # Partida 1: P1 vs P2
-        p1_after_match1_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player2], "win_a")
+        p1_after_match1_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player2], MatchResult.WIN_A)
         r_player1 = p1_after_match1_list[0]
         self.assertLess(r_player1.sigma, initial_sigma)
         sigma_after_1_match = r_player1.sigma
 
         # Partida 2: P1 vs P3
-        p1_after_match2_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player3], "win_a")
+        p1_after_match2_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player3], MatchResult.WIN_A)
         r_player1 = p1_after_match2_list[0]
         self.assertLess(r_player1.sigma, sigma_after_1_match)
         sigma_after_2_matches = r_player1.sigma
@@ -183,7 +183,7 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_p1_p2 = [r_player1, p2_rating_from_match1] # r_player1 (após partida 2) em equipe com r_player1 (após partida 1)
         team_p3_p4 = [r_player3, r_player4] # r_player3 e r_player4 ainda com ratings iniciais
 
-        p1_p2_after_match3_list, _ = ts_rating.update_ratings(self.env, team_p1_p2, team_p3_p4, "draw")
+        p1_p2_after_match3_list, _ = ts_rating.update_ratings(self.env, team_p1_p2, team_p3_p4, MatchResult.DRAW)
         r_player1 = p1_p2_after_match3_list[0]
         self.assertLess(r_player1.sigma, sigma_after_2_matches)
 


### PR DESCRIPTION
## Summary
- add `MatchResult` enum in `trueskill_rating`
- update `update_ratings` to accept `MatchResult`
- adjust pipeline to use enum-based results
- update tests for enum usage

## Testing
- `pip install requests pandas trueskill`
- `pip install toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c22ef5aa88325b085658a951752f3