### PR TITLE
Introduce typed MatchResult for TrueSkill ratings

### DIFF
--- a/causaganha/core/trueskill_rating.py
+++ b/causaganha/core/trueskill_rating.py
@@ -1,13 +1,26 @@
 # Este arquivo conterá a lógica para cálculos de rating usando TrueSkill.
 # Serão implementadas funções para inicializar e atualizar ratings.
-import trueskill
-import toml
+from __future__ import annotations
+
+from enum import Enum
 from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import toml
+import trueskill
+
+# Possíveis resultados de uma partida de TrueSkill
+class MatchResult(Enum):
+    """Representa o desfecho de uma partida para atualização de ratings."""
+
+    WIN_A = "win_a"
+    WIN_B = "win_b"
+    DRAW = "draw"
 
 # Carrega configurações do arquivo config.toml
 CONFIG_PATH = Path(__file__).resolve().parent.parent.parent / "config.toml"
 
-def load_trueskill_config():
+def load_trueskill_config() -> Dict[str, Any]:
     """Carrega as configurações do TrueSkill do arquivo config.toml."""
     try:
         config = toml.load(CONFIG_PATH)
@@ -51,18 +64,18 @@ def create_new_rating() -> trueskill.Rating:
     return ENV.create_rating()
 
 def update_ratings(
-    env: trueskill.TrueSkill, # Adicionado parâmetro env
+    env: trueskill.TrueSkill,
     team_ratings_a: list[trueskill.Rating],
     team_ratings_b: list[trueskill.Rating],
-    result: str, # "win_a", "win_b", "draw"
-) -> tuple[list[trueskill.Rating], list[trueskill.Rating]]:
+    result: MatchResult,
+) -> Tuple[list[trueskill.Rating], list[trueskill.Rating]]:
     """
     Atualiza os ratings TrueSkill para duas equipes com base no resultado da partida.
 
     Args:
         team_ratings_a: Lista de objetos Rating para a equipe A.
         team_ratings_b: Lista de objetos Rating para a equipe B.
-        result: String indicando o resultado ("win_a", "win_b", "draw").
+        result: Resultado da partida (:class:`MatchResult`).
 
     Returns:
         Uma tupla contendo duas listas:
@@ -72,14 +85,16 @@ def update_ratings(
     Raises:
         ValueError: Se o resultado fornecido for inválido.
     """
-    if result == "win_a":
+    if result == MatchResult.WIN_A:
         ranks = [0, 1]  # Posição 0 para o vencedor, 1 para o perdedor
-    elif result == "win_b":
+    elif result == MatchResult.WIN_B:
         ranks = [1, 0]
-    elif result == "draw":
+    elif result == MatchResult.DRAW:
         ranks = [0, 0]  # Mesma posição para empate
     else:
-        raise ValueError(f"Resultado desconhecido: {result}. Use 'win_a', 'win_b', ou 'draw'.")
+        raise ValueError(
+            f"Resultado desconhecido: {result}. Use 'win_a', 'win_b', ou 'draw'."
+        )
 
     new_team_a_ratings, new_team_b_ratings = env.rate([team_ratings_a, team_ratings_b], ranks=ranks)
     return new_team_a_ratings, new_team_b_ratings

--- a/causaganha/tests/test_trueskill_rating.py
+++ b/causaganha/tests/test_trueskill_rating.py
@@ -35,7 +35,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         """Testa se update_ratings levanta ValueError para um resultado inválido."""
         team_a = [self.r_alpha]
         team_b = [self.r_beta]
-        with self.assertRaisesRegex(ValueError, "Resultado desconhecido: non_existent_result"):
+        with self.assertRaisesRegex(
+            ValueError, "Resultado desconhecido: non_existent_result"
+        ):
             ts_rating.update_ratings(self.env, team_a, team_b, "non_existent_result")
 
     def test_update_ratings_1v1_win_a(self):
@@ -43,7 +45,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha]
         team_b_before = [self.r_beta] # r_beta tem o mesmo rating que r_alpha
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, ts_rating.MatchResult.WIN_A
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -70,7 +74,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [r_alpha_custom]
         team_b_before = [r_beta_custom]
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "draw")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, ts_rating.MatchResult.DRAW
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_b[0]
@@ -86,7 +92,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_alpha, self.r_beta] # Ambos com rating padrão
         team_b_before = [self.r_gamma]             # Rating padrão
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_a")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, ts_rating.MatchResult.WIN_A
+        )
 
         r_alpha_after = new_team_a[0]
         r_beta_after = new_team_a[1]
@@ -110,7 +118,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_a_before = [self.r_delta_expert] # Experiente
         team_b_before = [self.r_alpha]        # Novato (rating padrão)
 
-        new_team_a, new_team_b = ts_rating.update_ratings(self.env, team_a_before, team_b_before, "win_b")
+        new_team_a, new_team_b = ts_rating.update_ratings(
+            self.env, team_a_before, team_b_before, ts_rating.MatchResult.WIN_B
+        )
 
         r_delta_after = new_team_a[0]
         r_alpha_after = new_team_b[0]
@@ -132,7 +142,12 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         r_std2_before = self.env.create_rating() # Jogador B padrão
 
         # Jogo padrão: Jogador B (std2) vence Jogador A (std1)
-        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(self.env, [r_std1_before], [r_std2_before], "win_b")
+        r_std1_after_list, r_std2_after_list = ts_rating.update_ratings(
+            self.env,
+            [r_std1_before],
+            [r_std2_before],
+            ts_rating.MatchResult.WIN_B,
+        )
         r_std1_after = r_std1_after_list[0]
         r_std2_after = r_std2_after_list[0]
 
@@ -157,13 +172,17 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         initial_sigma = r_player1.sigma
 
         # Partida 1: P1 vs P2
-        p1_after_match1_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player2], "win_a")
+        p1_after_match1_list, _ = ts_rating.update_ratings(
+            self.env, [r_player1], [r_player2], ts_rating.MatchResult.WIN_A
+        )
         r_player1 = p1_after_match1_list[0]
         self.assertLess(r_player1.sigma, initial_sigma)
         sigma_after_1_match = r_player1.sigma
 
         # Partida 2: P1 vs P3
-        p1_after_match2_list, _ = ts_rating.update_ratings(self.env, [r_player1], [r_player3], "win_a")
+        p1_after_match2_list, _ = ts_rating.update_ratings(
+            self.env, [r_player1], [r_player3], ts_rating.MatchResult.WIN_A
+        )
         r_player1 = p1_after_match2_list[0]
         self.assertLess(r_player1.sigma, sigma_after_1_match)
         sigma_after_2_matches = r_player1.sigma
@@ -183,7 +202,9 @@ class TestTrueSkillRatingCalculations(unittest.TestCase):
         team_p1_p2 = [r_player1, p2_rating_from_match1] # r_player1 (após partida 2) em equipe com r_player1 (após partida 1)
         team_p3_p4 = [r_player3, r_player4] # r_player3 e r_player4 ainda com ratings iniciais
 
-        p1_p2_after_match3_list, _ = ts_rating.update_ratings(self.env, team_p1_p2, team_p3_p4, "draw")
+        p1_p2_after_match3_list, _ = ts_rating.update_ratings(
+            self.env, team_p1_p2, team_p3_p4, ts_rating.MatchResult.DRAW
+        )
         r_player1 = p1_p2_after_match3_list[0]
         self.assertLess(r_player1.sigma, sigma_after_2_matches)
 


### PR DESCRIPTION
## Summary
- add `MatchResult` enum and use it throughout `trueskill_rating.py`
- type annotate rating helpers and update logic
- switch pipeline utilities to use `MatchResult`
- adjust tests for new enum usage

## Testing
- `uv pip install requests pandas toml trueskill --system`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c2312e8bc8325813e3167389119c9