### PR TITLE
Grant write permission for error handler

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -312,12 +312,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: [collect, archive, extract, update, backup]
     if: always() && (needs.collect.result == 'failure' || needs.extract.result == 'failure' || needs.update.result == 'failure' || needs.archive.result == 'failure' || needs.backup.result == 'failure')
+    permissions:
+      contents: write
     
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
           
       - name: Create error debug branch
         run: |


### PR DESCRIPTION
## Summary
- adjust `.github/workflows/pipeline.yml` to add write permissions
- configure git identity for the `error_handler` job

## Testing
- `pytest -q` *(fails: 5 failed, 76 passed, 5 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685d38c6400c83259ac3d4eebe0a629b