### PR TITLE
Fix import path in pipeline CLI

### DIFF
--- a/causaganha/core/downloader.py
+++ b/causaganha/core/downloader.py
@@ -28,7 +28,7 @@ def fetch_tjro_pdf(
     """
     file_name = f"dj_{date_obj.strftime('%Y%m%d')}.pdf"
 
-    output_dir = pathlib.Path("data")
+    output_dir = pathlib.Path(__file__).resolve().parent.parent / "data" / "diarios"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / file_name
 
@@ -73,7 +73,7 @@ def fetch_latest_tjro_pdf() -> pathlib.Path | None:
     }
 
     # The ultimo-diario.php URL directly redirects to the PDF file
-    output_dir = pathlib.Path("data")
+    output_dir = pathlib.Path(__file__).resolve().parent.parent / "data" / "diarios"
     output_dir.mkdir(parents=True, exist_ok=True)
 
     try:

--- a/causaganha/core/pipeline.py
+++ b/causaganha/core/pipeline.py
@@ -1,3 +1,4 @@
+
 import argparse
 import logging
 from pathlib import Path
@@ -6,6 +7,11 @@ import json
 import shutil
 import pandas as pd
 import datetime
+
+# Allow running this file directly by adjusting sys.path so relative imports work
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    __package__ = "causaganha.core"
 
 from .downloader import fetch_tjro_pdf as _real_fetch_tjro_pdf
 from .extractor import GeminiExtractor as _RealGeminiExtractor
@@ -67,7 +73,7 @@ except ImportError as e:
 def fetch_tjro_pdf(date_str: str, dry_run: bool = False, verbose: bool = False):
     logger = logging.getLogger(__name__)
     if dry_run:
-        logger.info("DRY-RUN: Would fetch TJRO PDF for date: %s", date_str)
+        logger.info(f"DRY-RUN: Would fetch TJRO PDF for date: {date_str}")
         return Path(f"/tmp/fake_tjro_{date_str.replace('-', '')}.pdf")
 
     try:


### PR DESCRIPTION
## Summary
- adjust sys.path so `causaganha/core/pipeline.py` works when executed directly
- store TJRO PDFs inside `causaganha/data/diarios`
- refine dry-run logging message for CLI wrapper

## Testing
- `uv pip install --system -e .[dev]`
- `pytest -q` *(fails: test_dry_run_logging_capture_for_collect, test_file_compression, test_create_duckdb_snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_685d652ab68883258ba16b324e8b7484